### PR TITLE
introduce ALLOW_ONGOING_TESTS

### DIFF
--- a/src/config/arc/ArcanistArcConfigurationEngineExtension.php
+++ b/src/config/arc/ArcanistArcConfigurationEngineExtension.php
@@ -174,7 +174,8 @@ final class ArcanistArcConfigurationEngineExtension
           pht(
             'Rejected: You should not land revisions with failed or ongoing builds. '.
             'If you know what you are doing and still want to land, add a '.
-            '`ALLOW_FAILED_TESTS=<reason>` line to the revision summary and it will be audited.'))
+            '`ALLOW_FAILED_TESTS=<reason>` or `ALLOW_ONGOING_TESTS=<reason>` line to the '.
+            'revision summary and it will be audited.'))
         ->setSummary(
           pht(
             'Error message when attempting to land a revision with failed builds.')),


### PR DESCRIPTION
Our code yellow exit criteria specific this rate should be below 1%. Right now, many people just don't want to wait for their tests so they use this. We need to bifurcate the metrics so that one is for stability (`ALLOW_FAILED_TESTS`) and one is for time (`ALLOW_ONGOING_TESTS`).