### PR TITLE
only show a prompt if there is a prompt_key

### DIFF
--- a/src/land/engine/ArcanistLandEngine.php
+++ b/src/land/engine/ArcanistLandEngine.php
@@ -851,6 +851,8 @@ abstract class ArcanistLandEngine
       $build_map[$revision_phid]['buildRefs'][] = $build_ref;
     }
 
+    $prompt_key = '';
+    $query = '';
     if ($has_failures) {
       if ($has_ongoing) {
         $message = pht(
@@ -922,10 +924,12 @@ abstract class ArcanistLandEngine
       throw new ArcanistRevisionStatusException($this->getWorkflow()->getBuildFailuresMessage());
     }
 
-    $this->getWorkflow()
-      ->getPrompt($prompt_key)
-      ->setQuery($query)
-      ->execute();
+    if ($prompt_key && $query) {
+      $this->getWorkflow()
+        ->getPrompt($prompt_key)
+        ->setQuery($query)
+        ->execute();
+    }
   }
 
   protected function confirmImplicitCommits(array $sets, array $symbols) {


### PR DESCRIPTION
In https://phlq.build.rhinternal.net/log/D310097 I got:
```
[2021-11-10 21:52:20] EXCEPTION: (RuntimeException) Undefined variable: prompt_key at [<arcanist>/src/error/PhutilErrorHandler.php:236]
arcanist(), arcanist/linters()
  #0 PhutilErrorHandler::handleError(integer, string, string, integer, array) called at [<arcanist>/src/land/engine/ArcanistLandEngine.php:926]
  #1 ArcanistLandEngine::confirmBuilds(array) called at [<arcanist>/src/land/engine/ArcanistLandEngine.php:605]
  #2 ArcanistLandEngine::confirmRevisions(array) called at [<arcanist>/src/land/engine/ArcanistLandEngine.php:1431]
  #3 ArcanistLandEngine::execute() called at [<arcanist>/src/workflow/ArcanistLandWorkflow.php:375]
  #4 ArcanistLandWorkflow::runWorkflow(PhutilArgumentParser) called at [<arcanist>/src/workflow/ArcanistWorkflow.php:311]
  #5 ArcanistWorkflow::executeWorkflow(PhutilArgumentParser) called at [<arcanist>/src/toolset/ArcanistPhutilWorkflow.php:21]
  #6 ArcanistPhutilWorkflow::execute(PhutilArgumentParser) called at [<arcanist>/src/parser/argument/PhutilArgumentParser.php:492]
  #7 PhutilArgumentParser::parseWorkflowsFull(array) called at [<arcanist>/src/runtime/ArcanistRuntime.php:183]
  #8 ArcanistRuntime::executeCore(array) called at [<arcanist>/src/runtime/ArcanistRuntime.php:37]
  #9 ArcanistRuntime::execute(array) called at [<arcanist>/support/init/init-arcanist.php:6]
  #10 require_once(string) called at [<arcanist>/bin/arc:10]
```