### PR TITLE
[DevX] Default to rebase to stable branch before running arc diff

### DIFF
--- a/src/workflow/ArcanistDiffWorkflow.php
+++ b/src/workflow/ArcanistDiffWorkflow.php
@@ -335,7 +335,7 @@ EOTEXT
           'hg' => pht('Mercurial does not support %s yet.', '--head'),
         ),
       ),
-      'rebase' => array(
+      'no-rebase' => array(
         'help'  => pht('Rebase to stable before creating diff.'),
       )
     );
@@ -349,12 +349,13 @@ EOTEXT
 
   private function runRebaseToStable() {
     # return if continue creating the diff, true or false
-    # Default not rebase before creating a diff, will switch to true after fully tested.
+    # Default to rebase before creating a diff
     $do_rebase = false;
-    if ($this->getArgument('rebase')) {
+    if ($this->getArgument('no-rebase')) {
       $do_rebase = true;
     } 
     if ($do_rebase) {
+      exec('rm -fr ".git/rebase-merge"');
       echo "Running arc rebase... \n";
       $outputs = null;
       $retval = null;
@@ -368,7 +369,7 @@ EOTEXT
         $continue_diff = phutil_console_confirm($prompt, $default_no = true);
         if (!$continue_diff) {
           echo "Stop creating diff... \n";
-          echo "Please follow above console outputs to resolve all conflicts manually. \n";
+          echo "Please run 'arc rebase' and follow above console outputs to resolve all conflicts manually. \n";
           return false;
         }
         echo "Running git rebase --abort to skip rebase \n";


### PR DESCRIPTION
If we don't want to do the rebase, opt out by using `arc diff --no-rebase`.
Running `sw diff` or `arc diff` will all perform a rebase to stable branch first and create the diff. 

In terms of merging conflict, here's the output when choosing to skip rebase:
```
List of commits included in this stack:
[1/1] * 91f7e10ecf         asdgads
Running arc rebase...
 SHELL ALIAS  arc rebase -> $ eval '$(git rev-parse --show-toplevel)/arcanist/aliases/rebase.sh'
remote: Enumerating objects: 74, done.
remote: Counting objects: 100% (74/74), done.
remote: Compressing objects: 100% (9/9), done.
remote: Total 41 (delta 32), reused 39 (delta 30), pack-reused 0
Unpacking objects: 100% (41/41), 7.15 KiB | 178.00 KiB/s, done.
From github.com:robinhoodmarkets/rh
 * branch                    master     -> FETCH_HEAD
 * branch                    stable     -> FETCH_HEAD
   359fbc670e9..7b3cbae970b  master     -> origin/master
   dddee16b6f6..570dbbc5214  stable     -> origin/stable
error: could not apply 1736222285d... asdgads
Resolve all conflicts manually, mark them as resolved with
"git add/rm <conflicted_files>", then run "git rebase --continue".
You can instead skip this commit: run "git rebase --skip".
To abort and get back to the state before "git rebase", run "git rebase --abort".
Could not apply 1736222285d... asdgads
Returned with status 1 and outputs:
Branch 'master' set up to track remote branch 'master' from 'origin'.
Branch 'stable' set up to track remote branch 'stable' from 'origin'.
Auto-merging web/reldash/package.json
CONFLICT (content): Merge conflict in web/reldash/package.json


    arc rebase failed. You can skip the rebase and continue creating the diff
    with the original base commit, then deal with the merge conflicts later.
    Skip rebase? [y/N] y

Running git rebase --abort to skip rebase
```
and it will continue to create the diff. 

If we don't choose to skip the rebase, here's the terminal prompt:
```
CONFLICT (content): Merge conflict in spinner/jobs/data/piianchor_v2/scripts/generate_masked_event_new.py


    arc rebase failed. You can skip the rebase and continue creating the diff
    with the original base commit, then deal with the merge conflicts later.
    Skip rebase? [y/N] n

Stop creating diff...
Please run 'arc rebase' and follow above console outputs to resolve all conflicts manually.
00:02:05 [ERROR] arc diff failed
00:02:10 [ERROR] Rebase has failed
```