### PR TITLE
Only do auto rebase for rh monorepo

### DIFF
--- a/src/workflow/ArcanistDiffWorkflow.php
+++ b/src/workflow/ArcanistDiffWorkflow.php
@@ -357,6 +357,15 @@ EOTEXT
     if ($this->getArgument('no-rebase')) {
       $do_rebase = false;
     }
+    exec('git remote get-url origin', $remote_url, $git_remote_retval);
+    if ($git_remote_retval == 1) {
+      $do_rebase = false;
+      echo "Failed to execute `git remote get-url origin`, please check if you are under the correct repo.";
+    }
+    if ($remote_url[0] != "git@github.com:robinhoodmarkets/rh.git") {
+      $do_rebase = false;
+      echo "Will not perform the auto rebase since you are currently outside of `rh` monorepo.";
+    }
     if ($do_rebase) {
       echo "Running arc rebase... \n";
       $outputs = null;


### PR DESCRIPTION
Inside rh monorepo:
```
xici.luan in ~/robinhood/rh on buildkite-changes-build-cop
$ arc diff
Running arc rebase...
 SHELL ALIAS  arc rebase -> $ eval '$(git rev-parse --show-toplevel)/arcanist/aliases/rebase.sh'
remote: Enumerating objects: 5264, done.
remote: Counting objects: 100% (3224/3224), done.
remote: Compressing objects: 100% (1690/1690), done.
remote: Total 5264 (delta 1518), reused 3150 (delta 1455), pack-reused 2040
Receiving objects: 100% (5264/5264), 9.57 MiB | 3.28 MiB/s, done.
Resolving deltas: 100% (2253/2253), completed with 569 local objects.
From github.com:robinhoodmarkets/rh
 * branch                    master     -> FETCH_HEAD
 * branch                    stable     -> FETCH_HEAD
   20b7d9ea734..cc953cf27f0  master     -> origin/master
   6ebf7e7450c..cc953cf27f0  stable     -> origin/stable
Successfully rebased and updated refs/heads/buildkite-changes-build-cop.
```

Outside rh monorepo:
```
xici.luan in ~/robinhood/robinhood-trader-ios on tmp
$ arc diff
Will not perform the auto rebase since you are currently outside of `rh` monorepo.
Launching editor "vim"...
Provide the details for a new revision, then save and exit.
```