### PR TITLE
bug fix on auto rebase function 

### DIFF
--- a/src/workflow/ArcanistDiffWorkflow.php
+++ b/src/workflow/ArcanistDiffWorkflow.php
@@ -357,12 +357,16 @@ EOTEXT
     if ($this->getArgument('no-rebase')) {
       $do_rebase = false;
     }
+    if (file_exists(".git/rebase-merge")) {
+      $do_rebase = false;
+      echo "Seems like you are in middle of a rebase already, will not perform auto rebase.";
+    }
     exec('git remote get-url origin', $remote_url, $git_remote_retval);
     if ($git_remote_retval == 1) {
       $do_rebase = false;
       echo "Failed to execute `git remote get-url origin`, please check if you are under the correct repo.";
     }
-    if ($remote_url[0] != "git@github.com:robinhoodmarkets/rh.git") {
+    if ($remote_url[0] != "git@github.com:robinhoodmarkets/rh.git" && $remote_url[0] != "git@github.com:robinhoodmarkets/rh") {
       $do_rebase = false;
       echo "Will not perform the auto rebase since you are currently outside of `rh` monorepo.";
     }


### PR DESCRIPTION
1. Perform auto rebase when git origin is `git@github.com:robinhoodmarkets/rh`.
2. Do not perform auto rebase if already in middle of a rebase. 