### PR TITLE
Adding security scan step in arc diff workflow

### DIFF
--- a/scripts/secscan_scan_pre_push.sh
+++ b/scripts/secscan_scan_pre_push.sh
@@ -1,0 +1,20 @@
+#!/usr/bin/env bash
+
+# Exit if this process runs on non Robinhood machines
+if [[ "${EMAIL}" != *"@robinhood.com" ]]; then
+    exit 0
+fi
+
+set +o errexit
+
+bazel run --ui_event_filters=-info,-stdout,-stderr --noshow_progress //secscan -- scan -d ${HOME}/robinhood/rh/ -s=pre-commit
+
+EXIT_CODE=$?
+
+set -o errexit
+
+# Secscan exits with code 4 only in case where it has security findings,
+# we exit with failure in only that scenario
+# if [ $EXIT_CODE -eq 4 ]; then
+#     exit 1
+# fi

--- a/src/workflow/ArcanistDiffWorkflow.php
+++ b/src/workflow/ArcanistDiffWorkflow.php
@@ -399,6 +399,8 @@ EOTEXT
   }
 
   public function run() {
+    $this->runSecscanPrePushScript();
+
     $arc_diff_ts = (int)(microtime(true)*1000);
 
     $this->console = PhutilConsole::getConsole();
@@ -1246,6 +1248,25 @@ EOTEXT
     }
 
     return true;
+  }
+
+  private function runSecscanPrePushScript() {
+    $root = phutil_get_library_root('arcanist');
+
+    $script_path = $root.'/../scripts/secscan_scan_pre_push.sh';
+    $script_path = Filesystem::resolvePath($script_path);
+
+    $future = new ExecFuture('sh %C', $script_path);
+    $future->setTimeout(10);
+    $future->resolve();
+    // return true;
+
+    // list($err, $stdout, $stderr) = $future->resolve();
+
+    // if ($err == 1) {
+    //   echo $stderr;
+    //   return false;
+    // }
   }
 
 


### PR DESCRIPTION
This security step is set to run in the background within the arc diff workflow. We setup a timeout of 15 seconds for this command to handle latency scenarios. Our plan is to let it run in the background for a while and collect the execution data to enhance the product before enforcing it completely. 

**_Test plan:_** Tested locally to verify everything works as expected. Executed`arc diff` in different scenarios to verify it doesn't impact current workflow. Those scenarios are:
    a. When Bazel command fails to complete within 15 seconds, it exited safely with exit code 137. Since that command is wrapped with `set +o errexit` it did not impact the main flow.
    b. When Bazel command exits with either zero or non zero exit codes, it exited safely with no impact to the workflow.
    
**_How to test:_**
1. Replicate these changes at location where arc is pointed to `which arc`.
2. run `arc diff` to test the changes.
