### PR TITLE
[secscan] Add timeout for secscan command

### DIFF
--- a/scripts/secscan_scan_pre_push.sh
+++ b/scripts/secscan_scan_pre_push.sh
@@ -3,7 +3,7 @@
 set +o errexit
 REPO_PATH="$(git rev-parse --show-toplevel)"
 
-bazel run --ui_event_filters=-info,-stdout,-stderr --noshow_progress //secscan -- scan -d "${REPO_PATH}" -s=pre-commit
+bazel run --ui_event_filters=-info,-stdout,-stderr --noshow_progress //secscan -- scan -d "${REPO_PATH}" -s=pre-commit --timeout=8
 
 EXIT_CODE=$?
 


### PR DESCRIPTION
This ensures a timeout of `8 seconds` for the `secscan` command. This frees up bazel's resources.

For ref: https://phabricator.robinhood.com/D507525