### PR TITLE
Enable secret detection process by default

### DIFF
--- a/src/workflow/ArcanistDiffWorkflow.php
+++ b/src/workflow/ArcanistDiffWorkflow.php
@@ -443,10 +443,7 @@ EOTEXT
       $revision = $this->buildRevisionFromCommitMessage($commit_message);
     }
 
-    $runSecretDetector = false;
-    if (strtolower(getenv('ENABLE_SECRET_DETECTION_PROCESS')) == "true") {
-      $runSecretDetector = true;
-    }
+    $runSecretDetector = true;
 
     if (!($this->isProcessRunningInsideMonorepo())) {
       $runSecretDetector = false;


### PR DESCRIPTION
Since we added explicit timeout to Secscan command, we didn't observe users experience issues with Bazel blocking the diff creation workflow. We can now enable this process by default again.