### PR TITLE
allow test case escape hatches to be used interchangeably

### DIFF
--- a/src/land/engine/ArcanistLandEngine.php
+++ b/src/land/engine/ArcanistLandEngine.php
@@ -309,7 +309,7 @@ abstract class ArcanistLandEngine
   }
 
   final public function allowForcedLandWithFailingForceableTests($revision_refs) {
-    $expected_pattern = "/\sALLOW_FAILED_TESTS=.+/m";
+    $expected_pattern = "/\sALLOW_(FAILED|ONGOING)_TESTS=.+/m";
     $this->getWorkflow()->loadHardpoints(
       $revision_refs,
       array(
@@ -325,7 +325,7 @@ abstract class ArcanistLandEngine
   }
 
   final public function allowForcedLandWithOngoingForceableTests($revision_refs) {
-    $expected_pattern = "/\sALLOW_ONGOING_TESTS=.+/m";
+    $expected_pattern = "/\sALLOW_(FAILED|ONGOING)_TESTS=.+/m";
     $this->getWorkflow()->loadHardpoints(
       $revision_refs,
       array(


### PR DESCRIPTION
Feedback from stakeholder teams suggests that it is difficult to reason through whether failed or ongoing tests hatch should be used at the time that it is added. This diff updates arcanist to alleviate this pain by treating these strings as interchangeable.