### PR TITLE
Use minimal trufflehog scan target

### DIFF
--- a/scripts/secscan_scan_pre_push.sh
+++ b/scripts/secscan_scan_pre_push.sh
@@ -2,8 +2,16 @@
 
 set +o errexit
 REPO_PATH="$(git rev-parse --show-toplevel)"
+BASE_COMMIT=$(
+  git log \
+    --oneline \
+    --committer="phlq" \
+    --pretty="format:%H" \
+    --max-count=50 \
+    | head -1
+)
 
-bazel run --ui_event_filters=-info,-stdout,-stderr --noshow_progress //secscan -- scan -d "${REPO_PATH}" -s=pre-commit --timeout=8 --report-metrics=true --log-file="/tmp/secscan.log"
+bazel run --ui_event_filters=-info,-stdout,-stderr --noshow_progress //secscan/tools/trufflehog:scan_local -- $REPO_PATH $BASE_COMMIT
 
 EXIT_CODE=$?
 


### PR DESCRIPTION
Tested new target blocks secrets when running `arc diff` locally.