### PR TITLE
Invoke secscan in bash rather than sh

### DIFF
--- a/scripts/secscan_scan_pre_push.sh
+++ b/scripts/secscan_scan_pre_push.sh
@@ -1,5 +1,7 @@
 #!/usr/bin/env bash
 
+set -euo pipefail
+
 EVENT_FILE=$1
 
 START_TS=$(perl -MTime::HiRes=time -e 'printf "%.0f\n", time * 1000000')

--- a/src/workflow/ArcanistDiffWorkflow.php
+++ b/src/workflow/ArcanistDiffWorkflow.php
@@ -476,7 +476,7 @@ EOTEXT
       $event_file = $this->metricsEventLogger->getLogFile();
       $script_path = $root.'/../scripts/secscan_scan_pre_push.sh';
       $script_path = Filesystem::resolvePath($script_path);
-      $secretDetectorFuture = new ExecFuture('sh %C %s', $script_path, $event_file);
+      $secretDetectorFuture = new ExecFuture('bash %C %s', $script_path, $event_file);
       // temporary change to understand `bazel run` metrics of secret detection,
       // please remove this line after the experiment is done.
       $secretDetectorFuture->setTimeout(120);


### PR DESCRIPTION
Summary:
On macos sh seems to redirect to zsh, while in stays sh in linux. Pipefail does not work in sh. Bash should be installed on any machine.

Test Plan: running the script with different shells