### PR TITLE
Fix issues with arc diff metrics

### DIFF
--- a/src/config/arc/ArcanistArcConfigurationEngineExtension.php
+++ b/src/config/arc/ArcanistArcConfigurationEngineExtension.php
@@ -181,7 +181,7 @@ final class ArcanistArcConfigurationEngineExtension
             'Error message when attempting to land a revision with failed builds.')),
       id(new ArcanistBoolConfigOption())
         ->setKey('devx.metrics')
-        ->setDefaultValue(false)
+        ->setDefaultValue(true)
         ->setSummary(pht('Collect devx metrics.'))
         ->setHelp(pht('Collect devx metrics.')),
       id(new ArcanistBoolConfigOption())

--- a/src/lint/engine/ArcanistLintEngine.php
+++ b/src/lint/engine/ArcanistLintEngine.php
@@ -596,7 +596,7 @@ abstract class ArcanistLintEngine extends Phobject {
         'event_start_ts' => $willLintEventStartTs,
         'event_end_ts' => (int)(microtime(true)*1000000),
       ));
-    $lintPathsEventStartTs = (int)(microtime(true)*100000);
+    $lintPathsEventStartTs = (int)(microtime(true)*1000000);
 
     try {
       foreach ($paths as $path) {

--- a/src/metrics/ArcanistMetricsLogger.php
+++ b/src/metrics/ArcanistMetricsLogger.php
@@ -21,7 +21,7 @@ final class ArcanistMetricsLogger extends Phobject {
   private function __construct() {
     $this->eventFile = new TempFile();
     $repository_name;
-    exec('basename `git rev-parse --show-toplevel`', $repository_name);
+    exec('basename -s .git `git config --get remote.origin.url`', $repository_name);
     $this->setRepositoryName(implode(",",$repository_name));
     $this->setOsType(strtolower(php_uname('s')));
     $this->setCmdUuid($this->generateUuid());
@@ -79,7 +79,7 @@ final class ArcanistMetricsLogger extends Phobject {
   }
 
   public function setRevisionID($revisionID) {
-    if (empty($this->revisionID)) {
+    if (empty($this->revisionID) AND $revisionID != 'D') {
       $this->revisionID = $revisionID;
     }
   }

--- a/src/workflow/ArcanistDiffWorkflow.php
+++ b/src/workflow/ArcanistDiffWorkflow.php
@@ -691,6 +691,8 @@ EOTEXT
         echo pht('Created a new Differential revision:')."\n";
       }
 
+      $this->metricsEventLogger->setRevisionId('D'.$result_id);
+
       $uri = $result_uri;
       echo phutil_console_format(
         "        **%s** __%s__\n\n",


### PR DESCRIPTION
Fixing a few issues:
- make `devx.metric`s config default to true so that metrics are populated for all repositories by default
- parse repository name from remote origin url instead of local directory name 
- revisionID missing for new diffs created
- timestamp granularity typo